### PR TITLE
Add List-Unsubscribe headers

### DIFF
--- a/workers/email.js
+++ b/workers/email.js
@@ -125,7 +125,7 @@ module.exports = function(job, done){
   var toArr = job.data.to.email ? [job.data.to] : job.data.to;
   toArr.forEach(toObj => {
     var personalVariables = _.find(job.data.personalVariables, { rcpt: toObj.email });
-    var oneClickUnsubscribe = _.find(personalVariables, { name: 'RECIPIENT_UNSUB_URL' });
+    var oneClickUnsubscribe = _.find(personalVariables.vars, { name: 'RECIPIENT_UNSUB_URL' });
 
     mandrillClient.messages.sendTemplate({
       template_name: job.data.emailType, // template_name === tag === emailType


### PR DESCRIPTION
Attempts to make Habitica's outgoing emails compliant with https://datatracker.ietf.org/doc/html/rfc8058 . We could use the [MailChimp UNSUB feature](https://mailchimp.com/help/the-unsubscribe-merge-tag/), but that'd relinquish our ability to manage and store unsubscription preferences within our own code and database. Instead, the sacrifice we make is the ability to send a singular `mandrillClient.messages.sendTemplate` invocation with an array of recipients--in order to send different headers per recipient, we fire off each send individually. (I'm not certain we ever took advantage of the array option to begin with, though.)